### PR TITLE
Ensure system is not left without a MTA

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,12 +15,12 @@
 class postfix::install {
 
   package { 'sendmail':
-    ensure => absent,
+    ensure  => absent,
+    require => Package['postfix'],
   }
 
   package { 'postfix':
     ensure  => latest,
-    require => Package['sendmail'],
     notify  => Class['postfix::service'],
   }
 


### PR DESCRIPTION
Removing sendmail before installing postfix causes a package conflict if
other packages are installed which depend on having a MTA installed.
The easy fix is to remove sendmail after installing postfix.
