### PR TITLE
more useful templates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,24 +13,39 @@
 # Copyright 2013 EvenUp.
 #
 class postfix::config (
-  $mydomain,
-  $smtp_relay,
-  $tls,
-  $tls_bundle,
-  $tls_package,
-  $relay_networks,
-  $relay_domains,
-  $relay_host,
-  $relay_port,
-  $relay_username,
-  $relay_password
+  $mydomain                     = $postfix::mydomain,
+  $smtp_relay                   = $postfix::smtp_relay,
+  $tls                          = $postfix::tls,
+  $tls_bundle                   = $postfix::tls_bundle,
+  $tls_package                  = $postfix::tls_package,
+  $relay_networks               = $postfix::relay_networks,
+  $relay_domains                = $postfix::relay_domains,
+  $relay_host                   = $postfix::relay_host,
+  $relay_port                   = $postfix::relay_port,
+  $relay_username               = $postfix::relay_username,
+  $relay_password               = $postfix::relay_password,
+  $master_config_services       = [],
+  $main_options_hash            = hash([]),
+  $smtpd_client_restrictions    = 'permit_mynetworks, reject',
+  $smtpd_helo_restrictions      = undef,
+  $smtpd_sender_restrictions    = undef,
+  $smtpd_recipient_restrictions = 'permit_mynetworks, reject_unauth_destination',
+  $smtpd_data_restrictions      = 'reject_unauth_pipelining'
 ) {
+
+  validate_array($master_config_services)
+  validate_hash($main_options_hash)
+  validate_string($smtpd_client_restrictions)
+  validate_string($smtpd_helo_restrictions)
+  validate_string($smtpd_sender_restrictions)
+  validate_string($smtpd_recipient_restrictions)
+  validate_string($smtpd_data_restrictions)
 
   file { '/etc/postfix/master.cf':
     owner   => root,
     group   => root,
     mode    => '0444',
-    source  => 'puppet:///modules/postfix/master.cf',
+    content => template('postfix/master.cf.erb'),
     notify  => Class['postfix::service'],
   }
 

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -46,17 +46,22 @@ recipient_delimiter = +
 inet_protocols = ipv4
 
 # Allow connections from trusted networks only.
-smtpd_client_restrictions = permit_mynetworks, reject
+smtpd_client_restrictions = <%= @smtpd_client_restrictions %>
 
 # Don't talk to mail systems that don't know their own hostname.
 # With Postfix < 2.3, specify reject_unknown_hostname.
 #smtpd_helo_restrictions = reject_unknown_helo_hostname
+<% if @smtpd_helo_restrictions %>smtpd_helo_restrictions = <%= @smtpd_helo_restrictions %><% end %>
 
 # Don't accept mail from domains that don't exist.
 #smtpd_sender_restrictions = reject_unknown_sender_domain
+<% if @smtpd_sender_restrictions %>smtpd_sender_restrictions = <%= @smtpd_sender_restrictions %><% end %>
 
 # Whitelisting: local clients may specify any destination domain.
-smtpd_recipient_restrictions = permit_mynetworks, reject_unauth_destination
+smtpd_recipient_restrictions = <%= @smtpd_recipient_restrictions %>
 
 # Block clients that speak too early.
-smtpd_data_restrictions = reject_unauth_pipelining
+smtpd_data_restrictions = <%= @smtpd_data_restrictions %>
+
+<% @main_options_hash.each do |option,value| %>
+<%= option %> = <%= value %> <% end %>

--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -36,7 +36,7 @@ proxywrite unix -       -       n       -       1       proxymap
 smtp      unix  -       -       n       -       -       smtp
 # When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       n       -       -       smtp
-	-o smtp_fallback_relay=
+  -o smtp_fallback_relay=
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error
@@ -47,58 +47,6 @@ virtual   unix  -       n       n       -       -       virtual
 lmtp      unix  -       -       n       -       -       lmtp
 anvil     unix  -       -       n       -       1       anvil
 scache    unix  -       -       n       -       1       scache
-#
-# ====================================================================
-# Interfaces to non-Postfix software. Be sure to examine the manual
-# pages of the non-Postfix software to find out what options it wants.
-#
-# Many of the following services use the Postfix pipe(8) delivery
-# agent.  See the pipe(8) man page for information about ${recipient}
-# and other message envelope options.
-# ====================================================================
-#
-# maildrop. See the Postfix MAILDROP_README file for details.
-# Also specify in main.cf: maildrop_destination_recipient_limit=1
-#
-#maildrop  unix  -       n       n       -       -       pipe
-#  flags=DRhu user=vmail argv=/usr/local/bin/maildrop -d ${recipient}
-#
-# ====================================================================
-#
-# The Cyrus deliver program has changed incompatibly, multiple times.
-#
-#old-cyrus unix  -       n       n       -       -       pipe
-#  flags=R user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -m ${extension} ${user}
-#
-# ====================================================================
-#
-# Cyrus 2.1.5 (Amos Gouaux)
-# Also specify in main.cf: cyrus_destination_recipient_limit=1
-#
-#cyrus     unix  -       n       n       -       -       pipe
-#  user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -r ${sender} -m ${extension} ${user}
-#
-# ====================================================================
-#
-# See the Postfix UUCP_README file for configuration details.
-#
-#uucp      unix  -       n       n       -       -       pipe
-#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
-#
-# ====================================================================
-#
-# Other external delivery methods.
-#
-#ifmail    unix  -       n       n       -       -       pipe
-#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
-#
-#bsmtp     unix  -       n       n       -       -       pipe
-#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
-#
-#scalemail-backend unix -       n       n       -       2       pipe
-#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
-#  ${nexthop} ${user} ${extension}
-#
-#mailman   unix  -       n       n       -       -       pipe
-#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
-#  ${nexthop} ${user}
+
+# Include additional services defined by the postfix::config class.
+<% @master_config_services.each do |service| %><%= service %><% end %>


### PR DESCRIPTION
Extend the templates to enable defining any values for the smtpd_*_restrictions in main.cf.
Extend the templates to accept additional options not explicitly defined as parameters. This is especially useful for master.cf to allow additional services such as 'submission' on port 587 or custom smtp services on alternate ports. This is less useful in main.cf where most options are already defined and redefinition may not produce expected results.
