### PR TITLE
Extra parameters configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,27 @@ Default: 'permit_mynetworks, reject_unauth_destination'
 String Value of the smtpd_data_restrictions parameter.  
 Default: 'reject_unauth_pipelining'
 
+#####  `inet_interfaces`
+
+String. Value of the inet_interfaces parameter. The IP
+where the server listens on.
+Default: 'all' 
+
+#####  `inet_protocols`
+
+String. Value of the inet_protocols parameter. 
+Default: 'ipv4' 
+
+#####  `myhostname`
+
+String. Value of the myhostname parameter. 
+Default: undef
+
+#####  `myorigin`
+
+String. Value of the myorigin parameter. 
+Default: $::domain
+
 ### Private classes
 
 #### Class: `postfix::config`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,10 @@ class postfix::config (
   $smtpd_sender_restrictions    = $::postfix::smtpd_sender_restrictions,
   $smtpd_recipient_restrictions = $::postfix::smtpd_recipient_restrictions,
   $smtpd_data_restrictions      = $::postfix::smtpd_data_restrictions,
+  $inet_interfaces              = $::postfix::inet_interfaces,
+  $inet_protocols               = $::postfix::inet_protocols,
+  $myhostname                   = $::postfix::myhostname,
+  $myorigin                     = $::postfix::myorigin,
 ) {
 
   file { '/etc/postfix/master.cf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,10 @@ class postfix (
   $smtpd_sender_restrictions    = $postfix::params::smtpd_sender_restrictions,
   $smtpd_recipient_restrictions = $postfix::params::smtpd_recipient_restrictions,
   $smtpd_data_restrictions      = $postfix::params::smtpd_data_restrictions,
+  $inet_interfaces              = $::postfix::params::inet_interfaces,
+  $inet_protocols               = $::postfix::params::inet_protocols,
+  $myhostname                   = $::postfix::params::myhostname,
+  $myorigin                     = $::postfix::params::myorigin,
 ) inherits postfix::params {
 
   validate_bool($smtp_relay)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,10 +83,10 @@ class postfix (
   $smtpd_sender_restrictions    = $postfix::params::smtpd_sender_restrictions,
   $smtpd_recipient_restrictions = $postfix::params::smtpd_recipient_restrictions,
   $smtpd_data_restrictions      = $postfix::params::smtpd_data_restrictions,
-  $inet_interfaces              = $::postfix::params::inet_interfaces,
-  $inet_protocols               = $::postfix::params::inet_protocols,
-  $myhostname                   = $::postfix::params::myhostname,
-  $myorigin                     = $::postfix::params::myorigin,
+  $inet_interfaces              = $postfix::params::inet_interfaces,
+  $inet_protocols               = $postfix::params::inet_protocols,
+  $myhostname                   = $postfix::params::myhostname,
+  $myorigin                     = $postfix::params::myorigin,
 ) inherits postfix::params {
 
   validate_bool($smtp_relay)
@@ -105,7 +105,11 @@ class postfix (
   validate_string($smtpd_sender_restrictions)
   validate_string($smtpd_recipient_restrictions)
   validate_string($smtpd_data_restrictions)
-
+  validate_string($inet_interfaces)
+  validate_string($inet_protocols)
+  validate_string($myhostname)
+  validate_string($myorigin)
+  
   class { '::postfix::install': } ->
   class { '::postfix::config': } ~>
   class { '::postfix::service': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,10 +18,10 @@ class postfix::params {
   $smtpd_sender_restrictions    = undef
   $smtpd_recipient_restrictions = 'permit_mynetworks, reject_unauth_destination'
   $smtpd_data_restrictions      = 'reject_unauth_pipelining'
-  $inet_interfaces				= 'all'
-  $inet_protocols				= 'ipv4'
-  $myhostname					= undef
-  $myorigin						= $::domain
+  $inet_interfaces              = 'all'
+  $inet_protocols               = 'ipv4'
+  $myhostname                   = undef
+  $myorigin                     = $::domain
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,10 @@ class postfix::params {
   $smtpd_sender_restrictions    = undef
   $smtpd_recipient_restrictions = 'permit_mynetworks, reject_unauth_destination'
   $smtpd_data_restrictions      = 'reject_unauth_pipelining'
+  $inet_interfaces				= 'all'
+  $inet_protocols				= 'ipv4'
+  $myhostname					= undef
+  $myorigin						= $::domain
 
   case $::osfamily {
     'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jlambert121-postfix",
-  "version": "0.9.1",
+  "version": "0.9.0",
   "author": "Justin Lambert <jlambert@eml.com>",
   "license": "Apache-2.0",
   "summary": "Installs and manages the postfix service",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jlambert121-postfix",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Justin Lambert <jlambert@eml.com>",
   "license": "Apache-2.0",
   "summary": "Installs and manages the postfix service",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jlambert121-postfix",
-  "version": "0.9.0",
+  "version": "0.9.0-cmc-1.0",
   "author": "Justin Lambert <jlambert@eml.com>",
   "license": "Apache-2.0",
   "summary": "Installs and manages the postfix service",

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -14,9 +14,9 @@ readme_directory = no
 
 # TODO - should this be a generic name for relay hosts?
 <% if @myhostname -%>
-myhostname = <%= scope.lookupvar('::fqdn') %>
-<% else %>
 myhostname = <%= @myhostname %>
+<% else %>
+myhostname = <%= scope.lookupvar('::fqdn') %>
 <% end %>
 smtpd_banner = $myhostname ESMTP
 

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -2,7 +2,7 @@
 #
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 #
-smtpd_banner = $myhostname ESMTP
+
 biff = no
 
 # appending .domain is the MUA's job.
@@ -13,15 +13,21 @@ append_dot_mydomain = no
 readme_directory = no
 
 # TODO - should this be a generic name for relay hosts?
+<% if @myhostname -%>
 myhostname = <%= scope.lookupvar('::fqdn') %>
+<% else %>
+myhostname = <%= @myhostname %>
+<% end %>
+smtpd_banner = $myhostname ESMTP
+
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydomain = <%= @mydomain %>
-myorigin = $mydomain
+myorigin = <%= @myorigin %>
 mydestination = <%= scope.lookupvar('::fqdn') -%>, localhost.<%= scope.lookupvar('::domain') -%>, localhost
 <% if @smtp_relay -%>
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 <%= @relay_networks %>
-inet_interfaces = all
+inet_interfaces = <%= @inet_interfaces %>
 <% else %>
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 relayhost = <%= @relay_host -%>:<%= @relay_port %>
@@ -43,7 +49,7 @@ smtp_tls_CAfile = <%= @tls_bundle %>
 <% end -%>
 mailbox_size_limit = 0
 recipient_delimiter = +
-inet_protocols = ipv4
+inet_protocols = <%= @inet_protocols %>
 
 # Allow connections from trusted networks only.
 smtpd_client_restrictions = <%= @smtpd_client_restrictions %>


### PR DESCRIPTION
Simple change to add a few other variables from the main.cf that had set values to allow custom values if desired. I did not see any tests for any parameter value or presence testing, so didn't add any either. 

Do with this PR as you wish.

new main.cf variables:
inet_interfaces [default:  all] 
inet_protocols [default: ipv4]
myhostname [default:  undef]
myorigin [default: $::domain]
